### PR TITLE
Add mechanics for claims by human players

### DIFF
--- a/learning.py
+++ b/learning.py
@@ -166,7 +166,7 @@ class GameHandler:
             for h in claims:
                 if self.game.claims[h] != Team.NEITHER:
                     continue
-                self.game.commit_claim(claims[h])
+                self.game.commit_claim(p, claims[h])
 
     def play_interactive(self, model: Model, delay: int = 0) -> None:
         """

--- a/literature.py
+++ b/literature.py
@@ -75,6 +75,7 @@ class Team(Enum):
     EVEN = 0
     ODD = 1
     NEITHER = 2
+    DISCARD = 3
 
 
 def get_game(n_players: int) -> "Literature":
@@ -167,19 +168,46 @@ class Literature:
                 return p
         raise KeyError('There is no player with that ID')
 
-    def commit_claim(self, possessions: Dict[Card.Name, Actor]) -> bool:
+    def _claim_for_half_suit(self, h: HalfSuit) -> Dict[Card.Name, Actor]:
+        possessions: Dict[Card.Name, Actor] = {}
+        for c in [Card.Name(r, h.suit) for r in SETS[h.half]]:
+            for p in self.players:
+                if c in p.hand:
+                    possessions[c] = p
+        return possessions
+
+    def commit_claim(self,
+                     player: Actor,
+                     possessions: Dict[Card.Name, Actor]) -> bool:
         """
         Return whether or not the claim was successfully made.
 
         If the claim was successful, note that the `Team` successfully made
         the claim. We do not currently penalize incorrect claims, since the
         bots will never make a claim with uncertainty.
+
+        Parameters
+        ----------
+        player : Actor
+            The Player that is making the claim
+        possessions : Dict[Card.Name, Actor]
+            A map from card name to the Player who possesses the card. The
+            map must contain an entry for every card in the half suit, and all
+            Players in the map must belong to the same team.
         """
-        _validate_possessions(possessions)
+        _validate_possessions(player, possessions)
+
         claimed = set()
-        random_key = list(possessions.keys())[0]
-        half_suit = random_key.half_suit()
-        team = Team(possessions[random_key].unique_id % 2)
+        _random_key = list(possessions.keys())[0]
+        half_suit = _random_key.half_suit()
+
+        # Once a claim is submitted, all players must show the cards they
+        # have for that half suit
+        actual = self._claim_for_half_suit(half_suit)
+        for p in self.players:
+            p.memorize_claim(actual)
+
+        team = Team(player.unique_id % 2)
         for c, a in possessions.items():
             # Get the actual `Player` object, since `commit_claims` can
             # take an `Actor`.
@@ -191,16 +219,23 @@ class Literature:
                 for r in SETS[half_suit.half]]) != 6:
             self.logger.info('Team {0} failed to claim {1}'.format(team,
                                                                    half_suit))
+            if any(p.unique_id % 2 != player.unique_id % 2
+                   for p in actual.values()):
+                other = Team((player.unique_id + 1) % 2)
+                self.logger.info('The claim goes to team {0}'.format(other))
+                self.claims[half_suit] = other
+            else:
+                self.logger.info('The claim is discarded')
+                self.claims[half_suit] = Team.DISCARD
             return False
 
         self.claims[half_suit] = team
         self.logger.info('Team {0} successfully claimed {1}'.format(team,
                                                                     half_suit))
 
-        for p in self.players:
-            p.memorize_claim(possessions)
-
-        # Change the turn if needed
+        # Change the turn if needed. By default, the turn goes to the player
+        # who made the claim.
+        self.turn = self._actor_to_player(player)
         if self.turn.has_no_cards():
             self.logger.info('{0} is out of cards'.format(self.turn))
             teammates = [p for p in self.players
@@ -208,7 +243,7 @@ class Literature:
                          and not p.has_no_cards()]
             if len(teammates) == 0:
                 # If no teammates have any cards, the game should be finished.
-                # More claims might be made.
+                # More claims might be made by the opposing team.
                 return True
 
             self.turn = teammates[int(random.random() * len(teammates))]
@@ -253,13 +288,15 @@ class Literature:
         if not self.completed:
             raise ValueError('The game is not completed')
 
-        team_0 = sum([self.claims[HalfSuit(h, s)] == Team.EVEN
-                      for h in Half for s in Suit])
-        if team_0 > 4:
+        scores = {
+            t: sum(self.claims[HalfSuit(h, s)] == t for h in Half for s in Suit)
+            for t in Team
+        }
+        if scores[Team.EVEN] > scores[Team.ODD]:
             return Team.EVEN
-        if team_0 == 4:
-            return Team.NEITHER
-        return Team.ODD
+        elif scores[Team.ODD] > scores[Team.EVEN]:
+            return Team.ODD
+        return Team.NEITHER
 
     def _text_claim(self, move_components: List[str]) -> None:
         if move_components[0] != 'CLAIM':
@@ -274,7 +311,7 @@ class Literature:
             card_str = move_components.pop(0)
             card = _str_to_card(rank_str=card_str[:-1], suit_str=card_str[-1])
             claim[card] = actor
-        self.commit_claim(claim)
+        self.commit_claim(self.turn, claim)
 
     def _text_move(self, move_components: List[str]) -> None:
         if len(move_components) != 2:
@@ -285,14 +322,17 @@ class Literature:
         self.commit_move(self.turn.asks(player).to_give(card))
 
 
-def _validate_possessions(possessions: Dict[Card.Name, Actor]):
+def _validate_possessions(player: Actor, possessions: Dict[Card.Name, Actor]):
     """ Validate that the claim is defined properly. """
     if len(possessions) != 6:
         raise ValueError("You must specify exactly six cards' locations")
 
     actor_teams = [possessions[k].unique_id % 2 for k in possessions]
-    if not all(v == actor_teams[0] for v in actor_teams):
-        raise ValueError('All cards must belong to the same team')
+    if not all(v == player.unique_id % 2 for v in actor_teams):
+        raise ValueError(
+            'All cards must belong to the same team as the player ' +
+            'making the claim'
+        )
 
     half_suits = [c.half_suit() for c in possessions]
     if not all(h == half_suits[0] for h in half_suits):

--- a/player.py
+++ b/player.py
@@ -121,7 +121,7 @@ class Player(Actor):
 
     def has_no_cards(self):
         """ Return whether this `Player` is still in the game. """
-        return not any(c.half_suit() not in self.claims for c in self.hand)
+        return all(c.half_suit() in self.claims for c in self.hand)
 
     def _calculate_claim(self, half: HalfSuit) -> Dict[Card.Name, Actor]:
         """

--- a/test_game.py
+++ b/test_game.py
@@ -1,0 +1,72 @@
+""" Basic tests for the `Literature` class. """
+
+from typing import List
+
+import pytest
+
+from actor import Actor
+from card import (
+    Card,
+    Suit,
+    HalfSuit,
+    Half
+)
+from constants import SETS
+from literature import Literature, Team
+
+
+def two_player_mock(_: int) -> List[List[Card.Name]]:
+    return [
+        [Card.Name(r, s) for r in SETS[Half.MINOR] for s in Suit],
+        [Card.Name(r, s) for r in SETS[Half.MAJOR] for s in Suit],
+        [],
+        []
+    ]
+
+
+@pytest.fixture()
+def game():
+    # Give two players all of the cards
+    return Literature(4, hands_fn=two_player_mock, turn_picker=lambda: 0)
+
+
+def test_game_not_complete(game):
+    # There is no winner before the game is complete
+    with pytest.raises(ValueError):
+        assert game.winner == Team.NEITHER
+
+
+def test_turn_change(game):
+    assert not game.completed
+    assert game.turn == Actor(0)
+    claims_1 = game.players[1].evaluate_claims()
+    c = claims_1.pop(HalfSuit(Half.MAJOR, Suit.DIAMONDS))
+    game.commit_claim(Actor(1), c)
+    assert game.turn == Actor(1)
+
+
+def test_end_game_condition(game):
+    for c in game.players[0].evaluate_claims().values():
+        game.commit_claim(Actor(0), c)
+    assert game.completed
+    assert game.winner == Team.EVEN
+    # Allow claims after the game is over
+    for c in game.players[1].evaluate_claims().values():
+        game.commit_claim(Actor(1), c)
+    assert game.winner == Team.NEITHER
+
+
+def test_wrong_claim_conditions(game):
+    # Discard if we have all of the cards
+    claims_0 = game.players[0].evaluate_claims()
+    wrong_player = claims_0.pop(HalfSuit(Half.MINOR, Suit.DIAMONDS))
+    wrong_player[Card.Name(3, Suit.DIAMONDS)] = Actor(2)
+    game.commit_claim(Actor(0), wrong_player)
+    assert game.claims[HalfSuit(Half.MINOR, Suit.DIAMONDS)] == Team.DISCARD
+    # Award to the other team if we do not have all of the cards
+    claims_1 = game.players[1].evaluate_claims()
+    wrong_team = claims_1.pop(HalfSuit(Half.MAJOR, Suit.DIAMONDS))
+    for c in wrong_team:
+        wrong_team[c] = Actor(0)
+    game.commit_claim(Actor(0), wrong_team)
+    assert game.claims[HalfSuit(Half.MAJOR, Suit.DIAMONDS)] == Team.ODD

--- a/test_player.py
+++ b/test_player.py
@@ -105,6 +105,8 @@ def test_evaluate_claims(game):
 
     claims = player_0.evaluate_claims()
     assert HalfSuit(Half.MINOR, Suit.CLUBS) in claims and len(claims) == 1
+    # Ensure that we don't make claims for the opposing team
+    assert len(game.players[1].evaluate_claims()) == 0
 
 
 def test_learning_from_claims(single_player_game):

--- a/test_player.py
+++ b/test_player.py
@@ -111,7 +111,7 @@ def test_evaluate_claims(game):
 
 def test_learning_from_claims(single_player_game):
     claim = {Card.Name(r, Suit.CLUBS): Actor(0) for r in SETS[Half.MINOR]}
-    assert single_player_game.commit_claim(claim)
+    assert single_player_game.commit_claim(Actor(0), claim)
     player_1 = single_player_game.players[1]
     assert all([
         player_1.knowledge[Actor(0)][


### PR DESCRIPTION
We penalize wrong claims by:

- Discarding the claim if the player's team has all cards
- Awarding the claim to the opposing team if the player's team does not have all cards

We change the turn to the player who made the claim in the case of a correct claim.